### PR TITLE
fix for CmsCIRelation update call not updating relationState

### DIFF
--- a/src/main/java/com/oneops/cms/cm/dal/CIMapper.java
+++ b/src/main/java/com/oneops/cms/cm/dal/CIMapper.java
@@ -44,6 +44,7 @@ public interface CIMapper {
 	void updateCIAttribute(CmsCIAttribute attr);
 
 	void createRelation(CmsCIRelation rel);
+	void updateRelation(CmsCIRelation rel);
 	void addRelationAttribute(CmsCIRelationAttribute attr);
     void addRelationAttributeAndPublish(CmsCIRelationAttribute attr);
 	void deleteRelation(@Param("ciRelationId") long ciId, @Param("delete4real") boolean delete4real);

--- a/src/main/java/com/oneops/cms/cm/dal/CIMapper.xml
+++ b/src/main/java/com/oneops/cms/cm/dal/CIMapper.xml
@@ -43,9 +43,9 @@
 	    {call cm_create_relation(#{ciRelationId}, #{nsId}, #{fromCiId}, #{relationId}, #{toCiId}, #{relationGoid}, #{comments}, #{relationStateId})}
 	 </insert> 
 
-	<insert id="updateRelation" parameterType="com.oneops.cms.cm.domain.CmsCIRelation" statementType="CALLABLE">
+	<update id="updateRelation" parameterType="com.oneops.cms.cm.domain.CmsCIRelation" statementType="CALLABLE">
 		{call cm_update_rel(#{ciRelationId}, #{comments}, #{relationStateId}, null)}
-	</insert>
+	</update>
 
 	<insert id="addRelationAttribute" parameterType="com.oneops.cms.cm.domain.CmsCIRelationAttribute" statementType="CALLABLE">
 	    {call cm_add_ci_rel_attribute(#{ciRelationId}, #{attributeId}, #{dfValue}, #{djValue}, #{owner}, #{comments}, false, #{ciRelationAttributeId,jdbcType=BIGINT, mode=OUT})}

--- a/src/main/java/com/oneops/cms/cm/dal/CIMapper.xml
+++ b/src/main/java/com/oneops/cms/cm/dal/CIMapper.xml
@@ -43,7 +43,11 @@
 	    {call cm_create_relation(#{ciRelationId}, #{nsId}, #{fromCiId}, #{relationId}, #{toCiId}, #{relationGoid}, #{comments}, #{relationStateId})}
 	 </insert> 
 
-	 <insert id="addRelationAttribute" parameterType="com.oneops.cms.cm.domain.CmsCIRelationAttribute" statementType="CALLABLE">
+	<insert id="updateRelation" parameterType="com.oneops.cms.cm.domain.CmsCIRelation" statementType="CALLABLE">
+		{call cm_update_rel(#{ciRelationId}, #{comments}, #{relationStateId}, null)}
+	</insert>
+
+	<insert id="addRelationAttribute" parameterType="com.oneops.cms.cm.domain.CmsCIRelationAttribute" statementType="CALLABLE">
 	    {call cm_add_ci_rel_attribute(#{ciRelationId}, #{attributeId}, #{dfValue}, #{djValue}, #{owner}, #{comments}, false, #{ciRelationAttributeId,jdbcType=BIGINT, mode=OUT})}
 	 </insert> 
 

--- a/src/main/java/com/oneops/cms/cm/service/CmsCmProcessor.java
+++ b/src/main/java/com/oneops/cms/cm/service/CmsCmProcessor.java
@@ -1582,6 +1582,26 @@ public class CmsCmProcessor {
 		
 		CmsCIRelation existingRel = getRelationById(relation.getCiRelationId()); 
 
+		if (relation.getRelationState() != null && !relation.getRelationState().equals(existingRel.getRelationState())) {
+			Integer relStateId = ciMapper.getCiStateId(relation.getRelationState());
+			if (relStateId == null) {
+				throw new CIValidationException(CmsError.VALIDATION_COMMON_ERROR, "There is no such ci state defined - " + relation.getRelationState());
+			}
+			relation.setRelationStateId(relStateId);
+		} else if (relation.getRelationState() == null && relation.getRelationStateId() == 0
+				&& existingRel.getRelationStateId() > 0) {
+			logger.info("incoming update request rel :"+relation.getRelationId()+ " for state id= " + relation.getRelationStateId()
+					+ " existing ci state id = " + existingRel.getRelationStateId());
+			relation.setRelationStateId(existingRel.getRelationStateId());
+		} else if (relation.getRelationStateId() == 0) {
+			relation.setRelationStateId(100);
+		}
+
+        if (relation.getRelationStateId()!=existingRel.getRelationStateId() || (relation.getComments()!=null && !relation.getComments().equals(existingRel.getComments()))){
+            ciMapper.updateRelation(relation);
+        }
+
+
 		for(CmsCIRelationAttribute updAttr : relation.getAttributes().values()){
 			updAttr.setCiRelationId(relation.getCiRelationId());
 			

--- a/src/main/java/com/oneops/cms/dj/dal/DJMapper.java
+++ b/src/main/java/com/oneops/cms/dj/dal/DJMapper.java
@@ -56,7 +56,7 @@ public interface DJMapper {
 	CmsRfcCI getOpenRfcCIByCiId(long ciId);
 	List<CmsRfcCI> getOpenRfcCIByCiIdList(@Param("ciIds") List<Long> ciIds);
 	List<CmsRfcCI> getRfcCIBy3(@Param("releaseId") long releaseId,@Param("isActive") Boolean isActive,@Param("ciId") Long ciId);
-	List<CmsRfcCI> getOpenRfcCIByClazzAndName(@Param("nsPath") String nsPath, @Param("clazzName") String clazzName, @Param("ciName") String ciName);
+    List<CmsRfcCI> getRfcCIByClazzAndName(@Param("nsPath") String nsPath, @Param("clazzName") String clazzName, @Param("ciName") String ciName, @Param("isActive")Boolean isActive, @Param("state")String state);
 	List<CmsRfcCI> getOpenRfcCIByClazzAndNameLower(@Param("nsPath") String nsPath, @Param("clazzName") String clazzName, @Param("ciName") String ciName);
 	List<CmsRfcCI> getOpenRfcCIByNsLike(@Param("ns") String ns, @Param("nsLike") String nsLike, @Param("clazzName") String clazzName, @Param("ciName") String ciName);
 	List<CmsRfcCI> getOpenRfcCIByClazzAnd2Names(@Param("nsPath") String nsPath, @Param("clazzName") String clazzName, @Param("ciName") String ciName, @Param("altCiName") String altCiName);
@@ -74,7 +74,7 @@ public interface DJMapper {
 	CmsRfcRelation getOpenRfcRelationByCiRelId(long ciRelationId);
 	List<CmsRfcRelation> getRfcRelationByReleaseId(long releaseId);
 	List<CmsRfcRelation> getClosedRfcRelationByCiId(long ciId);
-	List<CmsRfcRelation> getOpenRfcRelationsByNs(String nsPath);
+	List<CmsRfcRelation> getRfcRelationsByNs(@Param("nsPath") String nsPath, @Param("isActive")Boolean isActive, @Param("state")String state);
 	List<CmsRfcRelation> getRfcRelationBy4(@Param("releaseId") long releaseId,@Param("isActive") Boolean isActive,@Param("fromCiId") Long fromCiId, @Param("toCiId") Long toCiId);
 	List<CmsRfcRelation> getOpenRfcRelationBy2(@Param("fromCiId") Long fromCiId, @Param("toCiId") Long toCiId, @Param("relName") String relName,@Param("shortRelName") String shortRelName);
 	List<CmsRfcRelation> getOpenFromRfcRelationByTargetClass(@Param("fromCiId") long fromCiId, @Param("relName") String relName, @Param("shortRelName") String shortRelName, @Param("targetClassName") String targetClassName);

--- a/src/main/java/com/oneops/cms/dj/dal/DJMapper.xml
+++ b/src/main/java/com/oneops/cms/dj/dal/DJMapper.xml
@@ -304,7 +304,8 @@
           and rci.action_id = a.action_id
 	 </select>
 
-	 <select id="getOpenRfcCIByClazzAndName" parameterType="map" useCache="false" resultType="com.oneops.cms.dj.domain.CmsRfcCI">
+
+	 <select id="getRfcCIByClazzAndName" parameterType="map" useCache="false" resultType="com.oneops.cms.dj.domain.CmsRfcCI">
 		SELECT 
 			rci.rfc_id as rfcId, 
 			rci.release_id as releaseId, 
@@ -336,8 +337,8 @@
           and (#{clazzName}::varchar is null or cl.class_name = #{clazzName})
           and rci.release_id = r.release_id
 		  and r.release_state_id = rs.release_state_id
-		  and rs.state_name = 'open'
-          and rci.is_active_in_release = true
+		  and (#{state}::varchar is null or rs.state_name = #{state})
+          and (#{isActive}::boolean is null or rci.is_active_in_release = #{isActive})
           and rci.ns_id = ns.ns_id
           and ns.ns_path = #{nsPath}
           and rci.class_id = cl.class_id
@@ -1004,7 +1005,7 @@
           and rfr.ns_id = ns.ns_id
 	 </select>
 
-	 <select id="getOpenRfcRelationsByNs" parameterType="string" useCache="false" resultType="com.oneops.cms.dj.domain.CmsRfcRelation">
+	 <select id="getRfcRelationsByNs" parameterType="map" useCache="false" resultType="com.oneops.cms.dj.domain.CmsRfcRelation">
 		SELECT rfr.rfc_id as rfcId, 
 			   rfr.release_id as releaseId, 
 			   rfr.ns_id as nsId,
@@ -1034,12 +1035,12 @@
         FROM dj_rfc_relation rfr, md_relations rel, dj_rfc_ci_actions a, dj_releases r, dj_release_states rs, ns_namespaces ns
         where rfr.release_id = r.release_id
           and r.release_state_id = rs.release_state_id
-          and rs.state_name = 'open'
-          and rfr.is_active_in_release = true
+          and (#{state}::varchar is null or rs.state_name = #{state})
+          and (#{isActive}::boolean is null or rfr.is_active_in_release = #{isActive})
           and rfr.relation_id = rel.relation_id
           and rfr.action_id = a.action_id
           and rfr.ns_id = ns.ns_id
-          and ns.ns_path = #{value}   
+          and ns.ns_path = #{nsPath}   
 	 </select>
 
 

--- a/src/main/java/com/oneops/cms/dj/service/CmsDjManager.java
+++ b/src/main/java/com/oneops/cms/dj/service/CmsDjManager.java
@@ -50,6 +50,7 @@ public interface CmsDjManager {
 	long rmRfcCiFromRelease(long rfcId);
 	List<CmsRfcCI> getRfcCIBy3(long releaseId, Boolean isActive, Long ciId);
     List<CmsRfcCI> getClosedRfcCIByCiId(long ciId);
+	List<CmsRfcCI> getRfcCIByNs(String nsPath, Boolean isActive);
     CmsRfcCI getRollUpRfc(long ciId, long rfcId);
 
     CmsRfcRelation createRfcRelation(CmsRfcRelation rel);
@@ -59,7 +60,8 @@ public interface CmsDjManager {
 	List<CmsRfcRelation> getRfcRelationByReleaseId(long releaseId);
 	List<CmsRfcRelation> getClosedRfcRelationByCiId(long ciId);
 	List<CmsRfcRelation> getRfcRelationBy3(long releaseId,Boolean isActive,Long fromCiId, Long toCiId);
-
+    List<CmsRfcRelation> getRfcRelationByNs(String nsPath, Boolean isActive);
+    
 	CmsDeployment deployRelease(long releaseId);
 	CmsDeployment createDeployment(CmsDeployment dpmt);
 	CmsDeployment getDeployment(long dpmtId);

--- a/src/main/java/com/oneops/cms/dj/service/CmsDjManagerImpl.java
+++ b/src/main/java/com/oneops/cms/dj/service/CmsDjManagerImpl.java
@@ -177,9 +177,17 @@ public class CmsDjManagerImpl implements CmsDjManager {
 		return rfcProcessor.getRfcCIBy3(releaseId, isActive, ciId);
 	}
 
-    /* (non-Javadoc)
-     * @see com.oneops.cms.dj.service.CmsDjManager#getClosedRfcCIByCiId(long)
-     */
+	/* (non-Javadoc)
+      * @see com.oneops.cms.dj.service.CmsDjManager#getRfcCIByNs(java.lang.String, java.lang.Boolean)
+      */ 
+     @Override
+     public List<CmsRfcCI> getRfcCIByNs(String nsPath, Boolean isActive) {
+         return rfcProcessor.getRfcCIByNs(nsPath, isActive);
+     }
+ 
+     /* (non-Javadoc)
+      * @see com.oneops.cms.dj.service.CmsDjManager#getClosedRfcCIByCiId(long)
+      */
     @Override
     public List<CmsRfcCI> getClosedRfcCIByCiId(long ciId) {
         return rfcProcessor.getClosedRfcCIByCiId(ciId);
@@ -236,9 +244,15 @@ public class CmsDjManagerImpl implements CmsDjManager {
 		return rfcProcessor.getRfcRelationBy4(releaseId, isActive, fromCiId, toCiId);
 	}
 
-	/* (non-Javadoc)
-	 * @see com.oneops.cms.dj.service.CmsDjManager#updateRfcRelation(com.oneops.cms.dj.domain.CmsRfcRelation)
-	 */
+
+    @Override
+    public List<CmsRfcRelation> getRfcRelationByNs(String nsPath, Boolean isActive) {
+        return rfcProcessor.getRfcRelationsByNs(nsPath, isActive, null);
+    }
+
+    /* (non-Javadoc)
+     * @see com.oneops.cms.dj.service.CmsDjManager#updateRfcRelation(com.oneops.cms.dj.domain.CmsRfcRelation)
+     */
 	@Override
 	public CmsRfcRelation updateRfcRelation(CmsRfcRelation rfcRelation) {
 		long newRfcId = rfcProcessor.updateRfcRelation(rfcRelation);

--- a/src/main/java/com/oneops/cms/dj/service/CmsRfcProcessor.java
+++ b/src/main/java/com/oneops/cms/dj/service/CmsRfcProcessor.java
@@ -839,7 +839,7 @@ public class CmsRfcProcessor {
 	 * @return the open rfc ci by clazz and name
 	 */
 	public List<CmsRfcCI> getOpenRfcCIByClazzAndName(String nsPath, String clazzName, String ciName) {
-		List<CmsRfcCI> rfcList = djMapper.getOpenRfcCIByClazzAndName(nsPath, clazzName, ciName);
+		List<CmsRfcCI> rfcList = djMapper.getRfcCIByClazzAndName(nsPath, clazzName, ciName,  true, "open");
 		populateRfcCIAttributes(rfcList);
 		return rfcList;
 	}
@@ -896,7 +896,7 @@ public class CmsRfcProcessor {
 	 * @return the open rfc ci by clazz and name no attrs
 	 */
 	public List<CmsRfcCI> getOpenRfcCIByClazzAndNameNoAttrs(String nsPath, String clazzName, String ciName) {
-		return djMapper.getOpenRfcCIByClazzAndName(nsPath, clazzName, ciName);
+		return djMapper.getRfcCIByClazzAndName(nsPath, clazzName, ciName,  true, "open");
 	}
 	
 	/**
@@ -926,6 +926,15 @@ public class CmsRfcProcessor {
 		populateRfcCIAttributes(rfcList);
 		return rfcList;
 	}
+
+    /**
+     * Gets the active (default if isActive missing) or inactive rfc ci by ns path.
+     * @param nsPath the ns path
+     * @param isActive    is active              
+     */               
+    public List<CmsRfcCI> getRfcCIByNs(String nsPath, Boolean isActive) {
+        return djMapper.getRfcCIByClazzAndName(nsPath, null, null, isActive, null);
+    }
 
 	
 	/**
@@ -1404,20 +1413,32 @@ public class CmsRfcProcessor {
 		List<CmsRfcRelation> relList = getOpenRfcRelationsNsLikeNakedNoAttrs(relationName, shortRelName, nsPath,fromClazzName, toClazzName);
 		populateRfcRelationAttributes(relList);
 		return relList;
-	}	
-	
-	/**
-	 * Gets the open rfc relations by ns
+	}
+
+    /**
+     * Gets the open rfc relations by ns
+     *
+     * @param nsPath the ns path
+     * @return the open rfc relations ns like naked
+     */
+    public List<CmsRfcRelation> getOpenRfcRelationsByNs(String nsPath) {
+        return getRfcRelationsByNs(nsPath, true, "open");
+    }
+
+
+    /**
+	 * Gets the rfc relations by ns
 	 *
 	 * @param nsPath the ns path
-	 * @return the open rfc relations ns like naked
+     * @param isActive is_active_in_release
+     * @param state                
+	 * @return the rfc relations with matching nsPath 
 	 */
-	public List<CmsRfcRelation> getOpenRfcRelationsByNs(String nsPath) {
-		List<CmsRfcRelation> relList = djMapper.getOpenRfcRelationsByNs(nsPath);
+	public List<CmsRfcRelation> getRfcRelationsByNs(String nsPath, Boolean isActive, String state) {
+		List<CmsRfcRelation> relList = djMapper.getRfcRelationsByNs(nsPath, isActive, state);
 		populateRfcRelationAttributes(relList);
 		return relList;
-	}	
-
+	}
 
 	/**
 	 * Gets the open rfc relations naked no attrs.


### PR DESCRIPTION
fix for CmsCIRelation update rest call 
PUT /cm/simple/relations/{ciRelId} 
ignoring new relationState (or comment) due to a missing update call